### PR TITLE
chore: remove unused set_str_prop helper

### DIFF
--- a/src/xfsm.c
+++ b/src/xfsm.c
@@ -248,10 +248,6 @@ static void set_status(JsVar *obj, const char *txt) {
   JsVar *v = jsvNewFromString(txt);
   jsvObjectSetChildAndUnLock(obj, K_STATUS, v);
 }
-static void set_str_prop(JsVar *obj, const char *k, const char *txt) {
-  JsVar *v = jsvNewFromString(txt);
-  jsvObjectSetChildAndUnLock(obj, k, v);
-}
 static int str_from_jsv(JsVar *s, char *buf, size_t bufSize) {
   if (!s || !jsvIsString(s) || bufSize == 0) return 0;
   size_t n = jsvGetString(s, buf, bufSize-1);


### PR DESCRIPTION
## Summary
- remove unused set_str_prop helper from `xfsm.c` utilities

## Testing
- `gcc -c src/xfsm.c -I src` *(fails: jsutils.h: No such file or directory)*
- `node test/testing/xfsm_TestSuite_AllRequirements_v2.js` *(fails: print is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68be7bcb7ce4832ebb29346da6076f61